### PR TITLE
Implement serializable uri

### DIFF
--- a/Editor/Common/SerializableConflict.cs
+++ b/Editor/Common/SerializableConflict.cs
@@ -11,7 +11,7 @@ namespace BatteryAcid.Serializables.Editor
 
         public bool IsConflicting => Index != -1 || OtherIndex != -1;
 
-        public void Clear()
+        public virtual void Clear()
         {
             Value = null;
             Index = -1;
@@ -29,7 +29,7 @@ namespace BatteryAcid.Serializables.Editor
         public object Key { get; set; }
         public bool IsKeyExpanded { get; set; }
 
-        public void Clear()
+        public override void Clear()
         {
             base.Clear();
             Key = null;

--- a/Editor/Serializable Uri.meta
+++ b/Editor/Serializable Uri.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7fcee98c1467d485c87ee844a7398007
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Serializable Uri/SerializableUriPropertyDrawer.cs
+++ b/Editor/Serializable Uri/SerializableUriPropertyDrawer.cs
@@ -1,0 +1,100 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using System;
+
+namespace BatteryAcid.Serializables.Editor
+{
+    [CustomPropertyDrawer(typeof(SerializableUri))]
+    public class SerializableUriPropertyDrawer : PropertyDrawer
+    {
+        private string Scheme { get; set; }
+        private string Authority { get; set; }
+        private string Path { get; set; }
+        private string Query { get; set; }
+        private string Fragment { get; set; }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            float totalHeight = EditorGUIUtility.singleLineHeight;
+            int availableParts = 0;
+            if (property.isExpanded)
+            {
+                if (!string.IsNullOrEmpty(Scheme)) availableParts++;
+                if (!string.IsNullOrEmpty(Authority)) availableParts++;
+                if (!string.IsNullOrEmpty(Path)) availableParts++;
+                if (!string.IsNullOrEmpty(Query)) availableParts++;
+                if (!string.IsNullOrEmpty(Fragment)) availableParts++;
+            }
+            return totalHeight + (EditorGUIUtility.singleLineHeight * availableParts);
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            SerializedProperty uriString = property.FindPropertyRelative("uriString");
+            ExtractUriParts(uriString.stringValue);
+
+            label = EditorGUI.BeginProperty(position, label, property);
+            Rect uriRect = new Rect(position.xMin + EditorGUIUtility.labelWidth + 2f, position.yMin, position.width - EditorGUIUtility.labelWidth, EditorGUIUtility.singleLineHeight);
+            Rect foldout = GetNextPropertyRect(ref position);
+            int indentLevel = EditorGUI.indentLevel;
+            if (property.isExpanded = EditorGUI.Foldout(foldout, property.isExpanded, label))
+            {
+                GUI.enabled = false;
+                EditorGUI.indentLevel = indentLevel + 1;
+                if (!string.IsNullOrEmpty(Scheme))
+                {
+                    EditorGUI.DelayedTextField(GetNextPropertyRect(ref position), "Scheme", Scheme);
+                }
+                if (!string.IsNullOrEmpty(Authority))
+                {
+                    EditorGUI.DelayedTextField(GetNextPropertyRect(ref position), "Authority", Authority);
+                }
+                if (!string.IsNullOrEmpty(Path))
+                {
+                    EditorGUI.DelayedTextField(GetNextPropertyRect(ref position), "Path", Path);
+                }
+                if (!string.IsNullOrEmpty(Query))
+                {
+                    EditorGUI.DelayedTextField(GetNextPropertyRect(ref position), "Query", Query);
+                }
+                if (!string.IsNullOrEmpty(Fragment))
+                {
+                    EditorGUI.DelayedTextField(GetNextPropertyRect(ref position), "Fragment", Fragment);
+                }
+                GUI.enabled = true;
+
+            }
+            EditorGUI.indentLevel = indentLevel;
+            string finalUri = EditorGUI.DelayedTextField(uriRect, "", uriString.stringValue);
+            if (Uri.IsWellFormedUriString(finalUri, UriKind.RelativeOrAbsolute))
+            {
+                uriString.stringValue = finalUri;
+            }
+            else
+            {
+                Debug.LogError("Failed to create Uri, incorrect Uri String.");
+            }
+        }
+
+        private void ExtractUriParts(string uriString)
+        {
+            Uri uri = new Uri(uriString);
+            Scheme = uri.Scheme;
+            Authority = uri.Authority;
+            Path = uri.AbsolutePath;
+            Query = uri.Query;
+            Fragment = uri.Fragment;
+        }
+
+        private Rect GetNextPropertyRect(ref Rect position, SerializedProperty property = null)
+        {
+            float height = property == null ? EditorGUIUtility.singleLineHeight : EditorGUI.GetPropertyHeight(property);
+            Rect r = new Rect(position.xMin, position.yMin, position.width, height);
+            float h = height + 1f;
+            position = new Rect(position.xMin, position.yMin + h, position.width, position.height = h);
+            return r;
+        }
+    }
+}

--- a/Editor/Serializable Uri/SerializableUriPropertyDrawer.cs.meta
+++ b/Editor/Serializable Uri/SerializableUriPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3caebeebf4b4c460ea76f8eecc567c72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Serializable Uri.meta
+++ b/Runtime/Serializable Uri.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ba788cd2900954e0fb15f9f1ebcc64b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Serializable Uri/SerializableUri.cs
+++ b/Runtime/Serializable Uri/SerializableUri.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BatteryAcid.Serializables
+{
+    [Serializable]
+    public class SerializableUri : ISerializationCallbackReceiver
+    {
+        private const string ExampleUri = "https://www.example.com";
+        public SerializableUri()
+            => uri = new Uri(ExampleUri);
+
+        public SerializableUri(string uriString)
+            => uri = new Uri(uriString);
+
+        public SerializableUri(Uri uri)
+            => this.uri = uri;
+
+        public SerializableUri(Uri baseUri, Uri relativeUri)
+            => uri = new Uri(baseUri, relativeUri);
+
+        public SerializableUri(string uriString, UriKind uriKind)
+            => uri = new Uri(uriString, uriKind);
+
+        private Uri uri;
+
+        [SerializeField, HideInInspector]
+        private string uriString;
+
+        public bool IsDefaultPort => uri.IsDefaultPort;
+        public string Authority => uri.Authority;
+        public string DnsSafeHost => uri.DnsSafeHost;
+        public string Fragment => uri.Fragment;
+        public string Host => uri.Host;
+        public UriHostNameType HostNameType => uri.HostNameType;
+        public string IdnHost => uri.IdnHost;
+        public bool IsAbsoluteUri => uri.IsAbsoluteUri;
+        public bool IsFile => uri.IsFile;
+        public string[] Segments => uri.Segments;
+        public bool IsUnc => uri.IsUnc;
+        public string LocalPath => uri.LocalPath;
+        public string OriginalString => uri.OriginalString;
+        public string PathAndQuery => uri.PathAndQuery;
+        public int Port => uri.Port;
+        public string Query => uri.Query;
+        public string Scheme => uri.Scheme;
+        public string AbsoluteUri => uri.AbsoluteUri;
+        public bool IsLoopback => uri.IsLoopback;
+        public string AbsolutePath => uri.AbsolutePath;
+        public string UserInfo => uri.UserInfo;
+        public bool UserEscaped => uri.UserEscaped;
+
+        public override bool Equals(object obj)
+        {
+            if (obj is SerializableUri serialized)
+            {
+                return serialized.uri == this.uri;
+            }
+            if (obj is Uri uri)
+            {
+                return this.uri == uri;
+            }
+            return base.Equals(obj);
+        }
+
+        public string GetComponents(UriComponents components, UriFormat format)
+            => uri.GetComponents(components, format);
+
+        public override int GetHashCode()
+            => uri.GetHashCode();
+
+        public string GetLeftPart(UriPartial part)
+            => uri.GetLeftPart(part);
+
+        public bool IsBaseOf(Uri uri)
+            => this.uri.IsBaseOf(uri);
+
+        public bool IsWellFormedOriginalString()
+            => uri.IsWellFormedOriginalString();
+
+        public Uri MakeRelativeUri(Uri uri)
+            => this.uri.MakeRelativeUri(uri);
+
+        public override string ToString()
+            => uri.ToString();
+
+        #region Operators
+
+        public static implicit operator Uri(SerializableUri serialized)
+            => serialized.uri;
+
+        public static implicit operator SerializableUri(Uri uri)
+            => new SerializableUri(uri);
+
+        public static bool operator ==(SerializableUri a, SerializableUri b)
+            => a.uri == b.uri;
+
+        public static bool operator !=(SerializableUri a, SerializableUri b)
+            => a.uri != b.uri;
+
+        public static bool operator ==(SerializableUri a, Uri b)
+            => a.uri == b;
+
+        public static bool operator !=(SerializableUri a, Uri b)
+            => a.uri != b;
+
+        public static bool operator ==(Uri a, SerializableUri b)
+            => a == b.uri;
+
+        public static bool operator !=(Uri a, SerializableUri b)
+            => a != b.uri;
+
+        #endregion
+
+        #region ISerializationCallbackReceiver
+
+        public void OnAfterDeserialize()
+        {
+            uri = new Uri(uriString);
+        }
+
+        public void OnBeforeSerialize()
+        {
+            uriString = uri.ToString();
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Serializable Uri/SerializableUri.cs.meta
+++ b/Runtime/Serializable Uri/SerializableUri.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2363d6b3d446143fd8dce7453608d44d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Resolves #8
Created wrapper for the C# System.Uri class that allows for the uri to be seen in the Editor as well as modify the Uri string.
Created the property drawer for the new serialized variant of Uri. Drawer can be unfolded to see the individual parts of the Uri such as Scheme, Authority, Path etc